### PR TITLE
Handle missing package.json or version attribute

### DIFF
--- a/src/cli/commands/printVersion.ts
+++ b/src/cli/commands/printVersion.ts
@@ -1,7 +1,11 @@
 const printVersion = () => {
-  return console.log(
-    `${process.env.npm_package_name} v${process.env.npm_package_version}`
-  );
+  if (typeof process.env.npm_package_version === 'undefined') {
+    console.warn('Warning: No version information found.');
+  } else {
+    console.log(
+      `${process.env.npm_package_name} v${process.env.npm_package_version}`
+    );
+  }
 };
 
 export { printVersion };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,8 +6,14 @@ import { printMarkdown } from './commands/printMarkdown';
 import { printVersion } from './commands/printVersion';
 import { flags } from './config/options';
 import { readConfigFile } from './config/readConfigFile';
+import { checkPackageJsonExists } from '../core/async';
 
 const run = async () => {
+  if (!checkPackageJsonExists()) {
+    console.error('Error: package.json does not exist.');
+    process.exit(1);
+  }
+
   const args = minimist<{
     version: undefined;
     config: string;

--- a/src/core/async.ts
+++ b/src/core/async.ts
@@ -1,5 +1,6 @@
+import { existsSync } from 'fs';
 import { exec } from 'child_process';
-import { mkdir, readFile, writeFile, existsSync } from 'fs';
+import { mkdir, readFile, writeFile } from 'fs';
 import { dirname } from 'path';
 import { promisify } from 'util';
 

--- a/src/core/async.ts
+++ b/src/core/async.ts
@@ -1,5 +1,5 @@
 import { exec } from 'child_process';
-import { mkdir, readFile, writeFile } from 'fs';
+import { mkdir, readFile, writeFile, existsSync } from 'fs';
 import { dirname } from 'path';
 import { promisify } from 'util';
 
@@ -13,4 +13,8 @@ const outputFileAsync = async (path: string, contents: string) => {
   await writeFileAsync(path, contents);
 };
 
-export { execAsync, writeFileAsync, readFileAsync, outputFileAsync };
+const checkPackageJsonExists = (): boolean => {
+  return existsSync('package.json');
+};
+
+export { execAsync, writeFileAsync, readFileAsync, outputFileAsync, checkPackageJsonExists };

--- a/src/core/async.ts
+++ b/src/core/async.ts
@@ -1,6 +1,5 @@
-import { existsSync } from 'fs';
 import { exec } from 'child_process';
-import { mkdir, readFile, writeFile } from 'fs';
+import { existsSync, mkdir, readFile, writeFile } from 'fs';
 import { dirname } from 'path';
 import { promisify } from 'util';
 
@@ -18,4 +17,10 @@ const checkPackageJsonExists = (): boolean => {
   return existsSync('package.json');
 };
 
-export { execAsync, writeFileAsync, readFileAsync, outputFileAsync, checkPackageJsonExists };
+export {
+  checkPackageJsonExists,
+  execAsync,
+  outputFileAsync,
+  readFileAsync,
+  writeFileAsync,
+};


### PR DESCRIPTION
Related to #1

Implements checks for `package.json` existence and version information before executing commands.

- **Version Check in `printVersion`**: Modifies `printVersion` in `src/cli/commands/printVersion.ts` to check if `process.env.npm_package_version` is defined before attempting to print the version. If undefined, it prints a warning message indicating the absence of version information.
- **Package.json Existence Check**: Adds a new function `checkPackageJsonExists` in `src/core/async.ts` that uses `fs.existsSync` to check for the existence of `package.json`. This ensures operations requiring `package.json` do not proceed without it.
- **Early Exit on Missing `package.json`**: Updates `src/cli/index.ts` to invoke `checkPackageJsonExists` at the start of the `run` function. If `package.json` does not exist, it prints an error message and exits the process immediately, preventing further execution.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PKief/changelog-machine/issues/1?shareId=64c01217-4d4b-4235-b5e4-95c77906da21).